### PR TITLE
Build on linux

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -3,5 +3,11 @@ MRuby::Gem::Specification.new('mruby-allegro') do |spec|
   spec.authors = 'cremno'
   # for the time being
   spec.cc.defines << %w(INIT_AT_START ALLEGRO_STATICLINK)
-  spec.mruby.linker.libraries << %w(allegro-5.0.8-monolith-static-mt-debug freetype-2.4.8-static-mt-debug user32 gdi32 opengl32 glu32 winmm ole32 shell32 shlwapi)
+  if ENV['OS'] == 'Windows_NT'
+    spec.linker.libraries << %w(allegro-5.0.8-monolith-static-mt-debug freetype-2.4.8-static-mt-debug user32 gdi32 opengl32 glu32 winmm ole32 shell32 shlwapi)
+  else
+    spec.cc.include_paths << ['/usr/local/include']
+    spec.linker.library_paths << ['/usr/local/lib']
+    spec.linker.libraries << ['allegro', 'allegro_primitives', 'allegro_font', 'allegro_ttf']
+  end
 end


### PR DESCRIPTION
allegro5 does not provide `allegro5-config` command. So added default include path or library path.
